### PR TITLE
Correct a typo

### DIFF
--- a/chapter01/01.2.md
+++ b/chapter01/01.2.md
@@ -8,7 +8,7 @@
 
 有时候我们需要传递一个io.ReadCloser的实例，而我们现在有一个io.Reader的实例，比如：strings.Reader，这个时候NopCloser就派上用场了。它包装一个io.Reader，返回一个io.ReadCloser，而相应的Close方法啥也不做，只是返回nil。
 
-比如，在标准库net/http包中的NewRequest，接收一个io.Reader的body，而实际上，Request的Body的类型是io.ReadCloser，因此，代码内部进行了判断，如果传递的io.Reader也实现了io.ReadCloser接口，则转换，否则通过ioutil.NoCloser包装转换一下。相关代码如下：
+比如，在标准库net/http包中的NewRequest，接收一个io.Reader的body，而实际上，Request的Body的类型是io.ReadCloser，因此，代码内部进行了判断，如果传递的io.Reader也实现了io.ReadCloser接口，则转换，否则通过ioutil.NopCloser包装转换一下。相关代码如下：
 
 	rc, ok := body.(io.ReadCloser)
 	if !ok && body != nil {


### PR DESCRIPTION
`NopCloser` was misspelled as `NoCloser`