### PR TITLE
Update 01.1.md

### DIFF
--- a/chapter01/01.1.md
+++ b/chapter01/01.1.md
@@ -202,7 +202,9 @@ if err != nil {
 }
 defer file.Close()
 file.WriteString("Golang中文社区——这里是多余的")
-n, err := file.WriteAt([]byte("Go语言中文网"), 24)
+n, err := file.WriteAt([]byte("Go语言中文网的"), 24)
+// file.WriteString("Golang中文社区——这里是多余")
+// n, err := file.WriteAt([]byte("Go语言中文网"), 24)
 if err != nil {
     panic(err)
 }


### PR DESCRIPTION
{用17个字节的内容去覆盖18个字节内容 导致多出来的一个字节无法标识 所以会出现乱码，解决方案是：覆盖者必须得被覆盖者长}

因为偏移量是24 而且要覆盖, 当不去掉目标中的 ‘的’导致字节不匹配出现乱码
所以 要么两边都放有’的‘来保证偏移后的字节数不出现错乱 ，要么两边都去掉保证后者比前者长，使得不出现字节错位导致乱码
（发现问题环境  go 1.10  ,macos height sierra 10.13.3）