### PR TITLE
Update book.json

### DIFF
--- a/book.json
+++ b/book.json
@@ -36,7 +36,7 @@
     ],
     "pluginsConfig": {
         "theme-default": {
-            "showLevel": true
+            "showLevel": false
         },
         "ba": {
             "token": "224c227cd9239761ec770bc8c1fb134c"


### PR DESCRIPTION
默认不展示序号，目前配置文件中配置了展示序号， gitbook 启动后，会出现三个序号，设置该配置为 false 会取消第一个。