### PR TITLE
[Update] fix the example error in 01.1.md

### DIFF
--- a/chapter01/01.1.md
+++ b/chapter01/01.1.md
@@ -309,7 +309,7 @@ type Seeker interface {
 
 ```go
 reader := strings.NewReader("Go语言中文网")
-reader.Seek(-6, io.SEEK_END)
+reader.Seek(-6, io.SeekEnd)
 r, _, _ := reader.ReadRune()
 fmt.Printf("%c\n", r)
 ```


### PR DESCRIPTION
 the example in 01.1.md, line 312, it should be io.SeekEnd rather than io.SEEK_END.